### PR TITLE
Added sudo true to task: Ensure redis is running and enabled on boot

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,3 +19,4 @@
 
 - name: Ensure redis is running and enabled on boot.
   service: "name={{ redis_daemon }} state=started enabled=yes"
+  sudo: true

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,3 +1,3 @@
 ---
-- name: Ensure redis is installed.
+- name: Ensure redis is installed (Debian).
   apt: name=redis-server state=installed

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,3 +1,3 @@
 ---
-- name: Ensure redis is installed.
+- name: Ensure redis is installed (RedHat).
   yum: name=redis state=installed enablerepo=epel


### PR DESCRIPTION
Since updating to 1.9 I have been getting
```msg: touch: cannot touch ‘/var/run/redis/redis-server.pid’: Permission denied```
As the sudo is not passed in from the playbook (known Ansible issues - fixed in dev I believe).
So I have forked this to update for my use - let me know if you think this is valid