### PR TITLE
Change PID file name on RedHat

### DIFF
--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -1,5 +1,5 @@
 daemonize yes
-pidfile /var/run/redis/{{ redis_dawmon }}.pid
+pidfile /var/run/redis/{{ redis_daemon }}.pid
 port {{ redis_port }}
 bind {{ redis_bind_interface }}
 

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -1,5 +1,5 @@
 daemonize yes
-pidfile /var/run/redis/redis-server.pid
+pidfile /var/run/redis/{{ redis_dawmon }}.pid
 port {{ redis_port }}
 bind {{ redis_bind_interface }}
 


### PR DESCRIPTION
The PID file name is hardcoded in /template/redis.conf.j2 to the Debian service daemon name.  This causes the 'service redis status' to fail on RedHat boxes.  This change is to fix this behavior on RedHat boxes.