### PR TITLE
Support maxmemory

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,24 +50,15 @@ Database compression and location configuration.
 
     redis_maxmemory: 0
     
-Limit memory usage to the specified amount of bytes. When the memory limit is reached Redis will try to remove keys according to the eviction policy selected (see redis_maxmemory_policy).
-Leave at 0 for no limit.
+Limit memory usage to the specified amount of bytes. Leave at 0 for unlimited.
 
-    redis_maxmemory_policy: "allkeys-lru"
+    redis_maxmemory_policy: "noeviction"
     
-How Redis will select what to remove when maxmemory is reached. You can select among five behaviors:
+The method to use to keep memory usage below the limit, if specified. See [Using Redis as an LRU cache](http://redis.io/topics/lru-cache).
 
-- "volatile-lru" > remove the key with an expire set using an LRU algorithm
-- "allkeys-lru" > remove any key according to the LRU algorithm
-- "volatile-random" > remove a random key with an expire set
-- "allkeys-random" > remove a random key, any key
-- "volatile-ttl" > remove the key with the nearest expire time (minor TTL)
-- "noeviction" > don't expire at all, just return an error on write operations
+    redis_maxmemory_samples: 5
 
-<!-- comment to allow code block after bullet list -->
-    redis_maxmemory_samples: "5"
-
-Number of samples to use to approximate LRU. The default of 5 produces good enough results. 10 Approximates true LRU very closely but costs a bit more CPU. 3 is very fast but not very accurate.
+Number of samples to use to approximate LRU. See [Using Redis as an LRU cache](http://redis.io/topics/lru-cache).
 
     redis_appendonly: "no"
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,27 @@ Snapshotting configuration; setting values in this list will save the database t
 
 Database compression and location configuration.
 
+    redis_maxmemory: 0
+    
+Limit memory usage to the specified amount of bytes. When the memory limit is reached Redis will try to remove keys according to the eviction policy selected (see redis_maxmemory_policy).
+Leave at 0 for no limit.
+
+    redis_maxmemory_policy: "allkeys-lru"
+    
+How Redis will select what to remove when maxmemory is reached. You can select among five behaviors:
+
+- "volatile-lru" > remove the key with an expire set using an LRU algorithm
+- "allkeys-lru" > remove any key according to the LRU algorithm
+- "volatile-random" > remove a random key with an expire set
+- "allkeys-random" > remove a random key, any key
+- "volatile-ttl" > remove the key with the nearest expire time (minor TTL)
+- "noeviction" > don't expire at all, just return an error on write operations
+
+<!-- comment to allow code block after bullet list -->
+    redis_maxmemory_samples: "5"
+
+Number of samples to use to approximate LRU. The default of 5 produces good enough results. 10 Approximates true LRU very closely but costs a bit more CPU. 3 is very fast but not very accurate.
+
     redis_appendonly: "no"
 
 The appendonly option, if enabled, affords better data durability guarantees, at the cost of slightly slower performance.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,7 @@ redis_dbfilename: dump.rdb
 redis_dbdir: /var/lib/redis
 
 redis_maxmemory: 0
-redis_maxmemory_policy: "allkeys-lru"
+redis_maxmemory_policy: "noeviction"
 redis_maxmemory_samples: 5
 
 redis_appendonly: "no"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,10 @@ redis_rdbcompression: "yes"
 redis_dbfilename: dump.rdb
 redis_dbdir: /var/lib/redis
 
+redis_maxmemory: 0
+redis_maxmemory_policy: "allkeys-lru"
+redis_maxmemory_samples: 5
+
 redis_appendonly: "no"
 redis_appendfsync: "everysec"
 

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -29,9 +29,10 @@ dbfilename {{ redis_dbfilename }}
 dir {{ redis_dbdir }}
 
 # maxclients 128
-# maxmemory <bytes>
-# maxmemory-policy volatile-lru
-# maxmemory-samples 3
+
+maxmemory {{ redis_maxmemory }}
+maxmemory-policy {{ redis_maxmemory_policy }}
+maxmemory-samples {{ redis_maxmemory_samples }}
 
 appendonly {{ redis_appendonly }}
 appendfsync {{ redis_appendfsync }}

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -30,9 +30,11 @@ dir {{ redis_dbdir }}
 
 # maxclients 128
 
+{% if redis_maxmemory %}
 maxmemory {{ redis_maxmemory }}
 maxmemory-policy {{ redis_maxmemory_policy }}
 maxmemory-samples {{ redis_maxmemory_samples }}
+{% endif %}
 
 appendonly {{ redis_appendonly }}
 appendfsync {{ redis_appendfsync }}


### PR DESCRIPTION
Allow specifying maxmemory and eviction policy .
This allows using redis as a LRU cache of limited size.