### PR TITLE
Allow including the main config template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     init: /usr/lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     redis_daemon: redis
+    test_playbook: test.yml
   # - distro: fedora24
   #   init: /usr/lib/systemd/systemd
   #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
@@ -14,6 +15,17 @@ env:
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     redis_daemon: redis-server
+    test_playbook: test.yml
+  - distro: ubuntu1604
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    redis_daemon: redis-server
+    test_playbook: test_with_include.yml
+  - distro: centos7
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    redis_daemon: redis
+    test_playbook: test_with_include.yml
 
 before_install:
   # Pull container.
@@ -25,14 +37,14 @@ script:
   - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
 
   # Ansible syntax check.
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/${test_playbook} --syntax-check'
 
   # Test role.
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/${test_playbook}'
 
   # Test role idempotence.
   - idempotence=$(mktemp)
-  - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml | tee -a ${idempotence}
+  - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/${test_playbook} | tee -a ${idempotence}
   - >
     tail ${idempotence}
     | grep -q 'changed=0.*failed=0'

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ On RedHat-based distributions, requires the EPEL repository (you can simply add 
 
 (Used only on RHEL/CentOS) The repository to use for Redis installation.
 
+    redis_use_include: false
+
+This places the configuration file into `/etc/redis/redis.conf.d/redis.conf` and includes it in the main config-file.
+This can be used e.g. when redis-sentinel modifies the original redis.conf.
+
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
     redis_port: 6379

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 # Used for RHEL/CentOS/Fedora only. Allows the use of different repos.
 redis_enablerepo: epel
 
+# Used to drop config in /etc/redis/redis.conf.d/*
+redis_use_include: false
+
 redis_port: 6379
 redis_bind_interface: 127.0.0.1
 redis_unixsocket: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,12 +15,36 @@
 - include: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
+- name: Ensure redis.conf.d exists
+  file:
+    name: /etc/redis/redis.conf.d
+    mode: 0755
+    state: directory
+  when: redis_use_include
+
+- name: Ensure Redis is configured in redis.conf.d
+  template:
+    src: redis.conf.j2
+    dest: /etc/redis/redis.conf.d/redis.conf
+    mode: 0644
+  notify: restart redis
+  when: redis_use_include
+
+- name: Ensure Redis is configured to read from redis.conf.d
+  lineinfile:
+    dest: "{{ redis_conf_path }}"
+    insertbefore: BOF
+    line: "include /etc/redis/redis.conf.d/redis.conf"
+  notify: restart redis
+  when: redis_use_include
+
 - name: Ensure Redis is configured.
   template:
     src: redis.conf.j2
     dest: "{{ redis_conf_path }}"
     mode: 0644
   notify: restart redis
+  when: not redis_use_include
 
 - name: Ensure Redis is running and enabled on boot.
   service: "name={{ redis_daemon }} state=started enabled=yes"

--- a/tests/test_with_include.yml
+++ b/tests/test_with_include.yml
@@ -1,0 +1,17 @@
+---
+- hosts: all
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes
+      when: ansible_os_family == 'Debian'
+
+    - name: Clear out repo for Fedora.
+      set_fact:
+        redis_enablerepo: ""
+      when: ansible_distribution == 'Fedora'
+
+  roles:
+    - { role: role_under_test,
+        redis_use_include: true }
+


### PR DESCRIPTION
This PR adds the `redis_use_include` role variable that, if set, writes the config to /etc/redis/redis.conf.d and adds the created file as an include to redis.conf (via lineinfile). This way, this role can be used to deploy a redis instance that is controlled by redis-sentinel. Because redis-sentinel issues the CONFIG REWRITE command, the config file created by this role is no longer idempotent. Using this new option, it is idempotent again.