### PR TITLE
Adding securized redis.conf capability

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,7 +37,7 @@ redis_includes: []
 redis_requirepass: ""
 
 # Disable these commands. Recommanded if Redis server is publicly opened.
-redis_disabled_command: []
+redis_disabled_commands: []
 #  - FLUSHDB
 #  - FLUSHALL
 #  - KEYS

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,3 +31,24 @@ redis_appendfsync: "everysec"
 
 # Add extra include files for local configuration/overrides.
 redis_includes: []
+
+# If set, activate Redis authentication with this password
+# Prefer long passwords. They may be generated with: echo "mypassword" | sha256sum
+redis_requirepass: ""
+
+# Disable these commands. Recommanded if Redis server is publicly opened.
+redis_disabled_command: []
+#  - FLUSHDB
+#  - FLUSHALL
+#  - KEYS
+#  - PEXPIRE
+#  - DEL
+#  - CONFIG
+#  - SHUTDOWN
+#  - BGREWRITEAOF
+#  - BGSAVE
+#  - SAVE
+#  - SPOP
+#  - SREM
+#  - RENAME
+#  - DEBUG

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -45,3 +45,11 @@ no-appendfsync-on-rewrite no
 {% for include in redis_includes %}
 include {{ include }}
 {% endfor %}
+
+{% if redis_requirepass %}
+requirepass {{ redis_requirepass }}
+{% endif %}
+
+{% for redis_disabled_command in redis_disabled_commands %}
+rename-command {{ redis_disabled_command }} ""
+{% endfor %}


### PR DESCRIPTION
Following best practices of Redis security: add requirepass configuration and disable dangerous commands.