### PR TITLE
add support for the syslog config file options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ Close a connection after a client is idle `N` seconds. Set to `0` to disable tim
 
 Log level and log location (valid levels are `debug`, `verbose`, `notice`, and `warning`).
 
+    redis_syslog_enabled: "yes"
+    redis_syslog_ident: redis
+    redis_syslog_facility: local0
+
+If `redis_syslog_enabled` is set to `"yes"`, Redis will log to syslog. The other two
+syslog variables are optional.
+
     redis_databases: 16
 
 The number of Redis databases.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,10 @@ redis_timeout: 300
 redis_loglevel: "notice"
 redis_logfile: /var/log/redis/redis-server.log
 
+redis_syslog_enabled: "no"
+redis_syslog_ident: redis
+redis_syslog_facility: local0
+
 redis_databases: 16
 
 # Set to an empty set to disable persistence (saving the DB to disk).

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -16,9 +16,9 @@ logfile {{ redis_logfile }}
 
 # To enable logging to the system logger, just set 'syslog-enabled' to yes,
 # and optionally update the other syslog parameters to suit your needs.
-# syslog-enabled no
-# syslog-ident redis
-# syslog-facility local0
+syslog-enabled {{ redis_syslog_enabled }}
+syslog-ident {{ redis_syslog_ident }}
+syslog-facility {{ redis_syslog_facility }}
 
 databases {{ redis_databases }}
 


### PR DESCRIPTION
Logging to syslog is disabled by default, mirrorring Redis' own default settings. Turning on syslogging is a matter of setting `redis_syslog_enable` to "yes".