### PR TITLE
Allow arbitrary extra configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ For extra security, you can disable certain Redis commands (this is especially i
       - CONFIG
       - SHUTDOWN
 
+Any additional configuration can be done using `redis_extra_configs: []`, for example:
+    
+    redis_extra_configs:
+      - "cluster-enabled yes"
+      - "slaveof 10.0.0.1 6379"
+
 ## Dependencies
 
 None.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Any additional configuration can be done using `redis_extra_configs: []`, for ex
     
     redis_extra_configs:
       - "cluster-enabled yes"
-      - "slaveof 10.0.0.1 6379"
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,3 +51,8 @@ redis_disabled_commands: []
 #  - SREM
 #  - RENAME
 #  - DEBUG
+
+# Extra free-form lines to put in the config
+redis_extra_configs: []
+#  - "cluster-enabled yes"
+#  - "... etc ..."

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -53,3 +53,7 @@ requirepass {{ redis_requirepass }}
 {% for redis_disabled_command in redis_disabled_commands %}
 rename-command {{ redis_disabled_command }} ""
 {% endfor %}
+
+{% for redis_extra_config in redis_extra_configs %}
+{{ redis_extra_config }}
+{% endfor %}


### PR DESCRIPTION
Allows arbitrary extra configs.

My use case was configuring redis in cluster mode where I need `cluster-enabled yes`, `slaveof`, `masterof` and related configs.

Until this gets merged the contents of this PR are available in galaxy here:
https://galaxy.ansible.com/emmetog/ansible_role_redis

Fixes #28 

