### PR TITLE
Allow spaces in password

### DIFF
--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -47,7 +47,7 @@ include {{ include }}
 {% endfor %}
 
 {% if redis_requirepass %}
-requirepass {{ redis_requirepass }}
+requirepass "{{ redis_requirepass }}"
 {% endif %}
 
 {% for redis_disabled_command in redis_disabled_commands %}


### PR DESCRIPTION
A simple tweak to allow using spaces in the Redis password (e.g. a passphrase).

Currently, using spaces in the password results in a corrupt configuration file:

```
redis-server[26891]: *** FATAL CONFIG FILE ERROR ***
redis-server[26891]: Reading the configuration file, at line 41
redis-server[26891]: >>> 'requirepass random password with spaces in it'
redis-server[26891]: Bad directive or wrong number of arguments
systemd[1]: redis-server.service: Control process exited, code=exited status=1
systemd[1]: redis-server.service: Failed with result 'exit-code'.
systemd[1]: Failed to start Advanced key-value store.
```