### PR TITLE
Restart service at end of role rather than waiting for handler at end of play

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,4 +26,4 @@
   notify: restart redis
 
 - name: Ensure Redis is running and enabled on boot.
-  service: "name={{ redis_daemon }} state=started enabled=yes"
+  service: "name={{ redis_daemon }} state=restarted enabled=yes"


### PR DESCRIPTION
Change started to restarted at end of role to be sure configuration changes take effect during longer playbooks where subsequent roles depend on configuration changes.