### PR TITLE
Fix #46: Add update cache for debian setup

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -3,3 +3,4 @@
   apt:
     name: "{{ redis_package }}"
     state: present
+    update_cache: yes


### PR DESCRIPTION
This role failed to install Redis on a fresh Debian machine.