### PR TITLE
Fix #39: Redis won't start with ipv6 disabled

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,19 @@
     redis_package: "{{ __redis_package }}"
   when: redis_package is not defined
 
+- name: Ensure Redis configuration dir exists.
+  file:
+    path: "{{ redis_conf_path | dirname }}"
+    state: directory
+    mode: 0755
+
+- name: Ensure Redis is configured.
+  template:
+    src: redis.conf.j2
+    dest: "{{ redis_conf_path }}"
+    mode: 0644
+  notify: restart redis
+
 # Setup/install tasks.
 - include_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
@@ -17,13 +30,6 @@
 
 - include_tasks: setup-Archlinux.yml
   when: ansible_os_family == 'Archlinux'
-
-- name: Ensure Redis is configured.
-  template:
-    src: redis.conf.j2
-    dest: "{{ redis_conf_path }}"
-    mode: 0644
-  notify: restart redis
 
 - name: Ensure Redis is running and enabled on boot.
   service: "name={{ redis_daemon }} state=started enabled=yes"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   template:
     src: redis.conf.j2
     dest: "{{ redis_conf_path }}"
-    mode: 0640
+    mode: "{{ redis_conf_mode }}"
   notify: restart redis
 
 # Setup/install tasks.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   template:
     src: redis.conf.j2
     dest: "{{ redis_conf_path }}"
-    mode: 0644
+    mode: 0640
   notify: restart redis
 
 # Setup/install tasks.

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,3 +2,4 @@
 __redis_package: redis-server
 redis_daemon: redis-server
 redis_conf_path: /etc/redis/redis.conf
+redis_conf_mode: 0640

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,3 +2,4 @@
 __redis_package: redis
 redis_daemon: redis
 redis_conf_path: /etc/redis.conf
+redis_conf_mode: 0644


### PR DESCRIPTION
Fixes #39 by putting config in place before installing a package