### PR TITLE
Add stop-writes-on-bgsave-error option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ The number of Redis databases.
 
 Snapshotting configuration; setting values in this list will save the database to disk if the given number of seconds (e.g. `900`) and the given number of write operations (e.g. `1`) have occurred.
 
+    stop-writes-on-bgsave-error: "yes"
+
+By default Redis will stop accepting writes if RDB snapshots are enabled (at least one save point) and the latest background save failed. If you have setup monitoring of the Redis server and persistence, you may want to disable (set `no`) this feature so that Redis will continue to work as usual even if there are problems with disk, permissions, and so forth.
+
     redis_rdbcompression: "yes"
     redis_dbfilename: dump.rdb
     redis_dbdir: /var/lib/redis

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,8 @@ redis_save:
   - 300 10
   - 60 10000
 
+redis_stop_writes_on_bgsave_error: "yes"
+
 redis_rdbcompression: "yes"
 redis_dbfilename: dump.rdb
 redis_dbdir: /var/lib/redis

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -25,6 +25,9 @@ databases {{ redis_databases }}
 {% for save in redis_save %}
 save {{ save }}
 {% endfor %}
+{% if redis_stop_writes_on_bgsave_error %}
+stop-writes-on-bgsave-error {{ redis_stop_writes_on_bgsave_error }}
+{% endif %}
 
 rdbcompression {{ redis_rdbcompression }}
 dbfilename {{ redis_dbfilename }}


### PR DESCRIPTION
Add stop-writes-on-bgsave-error option in ansible variables for changing this value in redis.conf.

Text in readme is shortened version of comment from [default redis.conf](https://raw.githubusercontent.com/redis/redis/6.0/redis.conf).

Tested on Ubuntu 18.04.2 with ansible 2.10.1.