### PR TITLE
Allow multiple lines in ansible_managed

### DIFF
--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 daemonize yes
 pidfile /var/run/redis/{{ redis_daemon }}.pid


### PR DESCRIPTION
## Problem

Currently if `ansible_managed` consists of multiple lines the comment is not properly applied.

### Solution

Use the builtin Jinja filter `comment`.