### PR TITLE
Reorder tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,16 @@
     redis_package: "{{ __redis_package }}"
   when: redis_package is not defined
 
+# Setup/install tasks.
+- include_tasks: setup-RedHat.yml
+  when: ansible_os_family == 'RedHat'
+
+- include_tasks: setup-Debian.yml
+  when: ansible_os_family == 'Debian'
+
+- include_tasks: setup-Archlinux.yml
+  when: ansible_os_family == 'Archlinux'
+
 - name: Ensure Redis configuration dir exists.
   file:
     path: "{{ redis_conf_path | dirname }}"
@@ -20,16 +30,6 @@
     dest: "{{ redis_conf_path }}"
     mode: "{{ redis_conf_mode }}"
   notify: restart redis
-
-# Setup/install tasks.
-- include_tasks: setup-RedHat.yml
-  when: ansible_os_family == 'RedHat'
-
-- include_tasks: setup-Debian.yml
-  when: ansible_os_family == 'Debian'
-
-- include_tasks: setup-Archlinux.yml
-  when: ansible_os_family == 'Archlinux'
 
 - name: Ensure Redis is running and enabled on boot.
   service: "name={{ redis_daemon }} state=started enabled=yes"


### PR DESCRIPTION
This should keep idempotence tests from failing.

As far as I understand, installing the package over the already placed configuration file can break idempotence tests. Maybe due to permissions changed or something similar.

It might lead to Redis starting with a default config and being immediately restarted afterwards on deb systems but at least I'm ok with that.