### PR TITLE
Add stop-writes-on-bgsave-error to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ For extra security, you can disable certain Redis commands (this is especially i
       - CONFIG
       - SHUTDOWN
 
+Stop write actions if Redis can't take RDB snapshots. Disabling this default setting is especially important if you're using Redis as a FIFO puffer (e.g. for Logmanagement). Redis can reach a level of filling that will prohibit even removing data thus leading to a state where you can't write nor delete from it and you're stuck. Remember to put monitoring in place if you disable this. Possible values: `yes` or `no`.
+
+    redis_stop_writes_on_bgsave_error: yes
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,3 +51,5 @@ redis_disabled_commands: []
 #  - SREM
 #  - RENAME
 #  - DEBUG
+
+redis_stop-writes-on-bgsave-error: yes

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -53,3 +53,5 @@ requirepass {{ redis_requirepass }}
 {% for redis_disabled_command in redis_disabled_commands %}
 rename-command {{ redis_disabled_command }} ""
 {% endfor %}
+
+stop-writes-on-bgsave-error {{ redis_stop_writes_on_bgsave_error }}


### PR DESCRIPTION
The Change to `README.md` should explain why this helps. It's especially important when using Redis in connection with Logstash.