### PR TITLE
Explicitly disable RDB persistence using save ""

### DIFF
--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -22,9 +22,13 @@ logfile {{ redis_logfile }}
 
 databases {{ redis_databases }}
 
+{% if redis_save | length > 0 %}
 {% for save in redis_save %}
 save {{ save }}
 {% endfor %}
+{% else %}
+save ""
+{% endif %}
 
 rdbcompression {{ redis_rdbcompression }}
 dbfilename {{ redis_dbfilename }}


### PR DESCRIPTION
Fixes https://github.com/geerlingguy/ansible-role-redis/issues/73

If `redis_save` is an empty list `save ""` is written to the redis conf file.