### PR TITLE
Fix: Prevent redis.conf from being readable by everyone

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,4 +2,4 @@
 __redis_package: redis
 redis_daemon: redis
 redis_conf_path: /etc/redis.conf
-redis_conf_mode: 0644
+redis_conf_mode: 0640


### PR DESCRIPTION
Prevent redis.conf from being readable by everyone because it may contain password