### PR TITLE
fix conf file path

### DIFF
--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,4 +1,4 @@
 ---
 __redis_package: redis
 redis_daemon: redis
-redis_conf_path: /etc/redis.conf
+redis_conf_path: /etc/redis/redis.conf


### PR DESCRIPTION
as documented here, archlinux puts the redis.conf into /etc/redis

https://archlinux.org/packages/extra/x86_64/redis/

it also puts redis-sentinel conf there, by the way, as sentinel.conf