### PR TITLE
[bug fix] Update octal permission syntax

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
   file:
     path: "{{ redis_conf_path | dirname }}"
     state: directory
-    mode: 0755
+    mode: '0755'
 
 - name: Ensure Redis is configured.
   template:


### PR DESCRIPTION
I was working on an ansible role for nocodb but I could not manage to pass idempotent test on [this workflow](https://github.com/chadek/ansible-role-nocodb/actions/runs/7877032497/job/21492317280?pr=5) because of a really weird behavior of this role that I use as a dependency: first run create configuration dir folder, at second run, it appears the folder as 02755 permission instead of 0755, so it set permission again. It appears that it might be because of octal permission syntax which can lead to inconsistent result according to file module documentation quoted below.

> For those used to /usr/bin/chmod remember that modes are actually octal numbers. You must give Ansible enough information to parse them correctly. For consistent results, quote octal numbers (for example, '644' or '1777') so Ansible receives a string and can do its own conversion from string into number. Adding a leading zero (for example, 0755) works sometimes, but can fail in loops and some other circumstances.