### PR TITLE
[Close #77] fix: set redis_conf_mode for Arch Linux

### DIFF
--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -2,3 +2,4 @@
 __redis_package: redis
 redis_daemon: redis
 redis_conf_path: /etc/redis.conf
+redis_conf_mode: 0640

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,5 +1,5 @@
 ---
 __redis_package: redis
 redis_daemon: redis
-redis_conf_path: /etc/redis.conf
+redis_conf_path: /etc/redis/redis.conf
 redis_conf_mode: 0640


### PR DESCRIPTION
The var redis_conf_mode is missing for Arch Linux