### PR TITLE
update apt cache on Debian setup

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -3,3 +3,4 @@
   apt:
     name: "{{ redis_package }}"
     state: present
+    update_cache: yes


### PR DESCRIPTION
Fix the following on the new Ubuntu host
```shell
fatal: [172.30.1.236]: FAILED! => {"changed": false, "msg": "No package matching 'redis-server' is available"}
```