### PR TITLE
Allow not starting Redis at boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ redis_enablerepo: epel
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
 ```yaml
+redis_enabled: true
+```
+
+If unset, Redis will not start at boot.
+
+```yaml
 redis_port: 6379
 redis_bind_interface: 127.0.0.1
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 # Used for RHEL/CentOS/Fedora only. Allows the use of different repos.
 redis_enablerepo: epel
 
+redis_enabled: true
+
 redis_port: 6379
 redis_bind_interface: 127.0.0.1
 redis_unixsocket: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,4 +32,7 @@
   when: ansible_os_family == 'Archlinux'
 
 - name: Ensure Redis is running and enabled on boot.
-  service: "name={{ redis_daemon }} state=started enabled=yes"
+  service:
+    name: "{{ redis_daemon }}"
+    state: started 
+    enabled: "{{ redis_enabled }}"


### PR DESCRIPTION
Forcefully starting Redis at boot can interfere with other system configurations. 