### PR TITLE
Change `redis_package_name` to `redis_package` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Add extra include file paths to this list to include more/localized Redis config
 The redis package name for installation via the system package manager. Defaults to `redis-server` on Debian and `redis` on RHEL.
 
 ```yaml
-redis_package_name: "redis-server"
+redis_package: "redis-server"
 ```
 
 (Default for RHEL shown) The redis package name for installation via the system package manager. Defaults to `redis-server` on Debian and `redis` on RHEL.


### PR DESCRIPTION
This variable was renamed in a [previous commit](https://github.com/geerlingguy/ansible-role-redis/commit/5bf1957da0ee523080e9d7af132f15d5b40e0cbc).