### PR TITLE
fixes wrong defaults for archlinux config file

### DIFF
--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,4 +1,5 @@
 ---
 __redis_package: redis
 redis_daemon: redis
-redis_conf_path: /etc/redis.conf
+redis_conf_path: /etc/redis/redis.conf
+redis_conf_mode: 0640


### PR DESCRIPTION
This fixes the wrong path location of redis.conf in and file mode  in archlinux.

Fixes #92 #77 
First proposed by @volker-raschek in #82 